### PR TITLE
Demonstrate using ranges::fold_left

### DIFF
--- a/Chapter2.2/main.cpp
+++ b/Chapter2.2/main.cpp
@@ -129,7 +129,9 @@ void check_properties(const std::vector<std::vector<int>> & triangle)
         assert(row.front() == 1);
         assert(row.back() == 1);
         assert(row.size() == row_number++);
-
+        assert(std::ranges::fold_left(row, 0, std::plus<>())
+            == expected_total);
+        // If your compiler doesn't support ranges, use std::accumulate instead:
         assert(std::accumulate(row.begin(),
             row.end(),
             0)


### PR DESCRIPTION
Your book says in 2.3.3 "We noted earlier that some algorithms support ranges, but some, including accumulate, do not"
Barry Revzin fixed this with P2322R6, which was voted into C++23 (and available gcc since 13 and Visual Studio 2022 since version 17.5)